### PR TITLE
Linux Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ tasks.jpackage {
     windows {
         winConsole = false
     }
+    linux {
+        appName = "emrick-designer"
+    }
 }
 
 

--- a/build.sh
+++ b/build.sh
@@ -11,14 +11,13 @@
 
 
 VERSION="1.0.1"
-DIR="./build/dist/$VERSION/Emrick-Designer"
-NAME="Emrick-Designer"
+DIR="./build/dist/$VERSION/emrick-designer"
+NAME="emrick-designer"
 
 ./gradlew clean
 ./gradlew jpackage
 
 mkdir -p $DIR
-cp -r ./src "$DIR/src/"
+cp -r ./src/main/resources "$DIR/res/"
 echo "File Copied"
-jpackage --type rpm --app-image "$DIR" --name "$NAME" --app-version "$VERSION" -d "./build/dist" --file-associations "FAemrick.properties" --file-associations "FApacket.properties" --linux-package-name "$NAME"
-cd
+jpackage --type deb --app-image "$DIR" --name "$NAME" --app-version "$VERSION" -d "./build/dist" --file-associations "FAemrick.properties" --file-associations "FApacket.properties" --linux-package-name "$NAME"

--- a/src/main/java/org/emrick/project/PathConverter.java
+++ b/src/main/java/org/emrick/project/PathConverter.java
@@ -7,14 +7,17 @@ public class PathConverter {
             if (System.getProperty("os.name").toLowerCase().contains("windows")) {
                 return System.getProperty("user.home") + "/AppData/Local/Emrick Designer/" + path;
             } else if (System.getProperty("os.name").toLowerCase().contains("linux")) {
-                return "/Desktop/Emrick-Designer/" + path;
+                return System.getProperty("user.home") + "/Desktop/emrick-designer/" + path;
             } else {
                 return "/Applications/Emrick Designer.app/Contents/" + path;
             }
         } else {
             if (System.getProperty("os.name").toLowerCase().contains("windows")) {
                 return System.getenv("PROGRAMFILES") + "/Emrick Designer/" + path;
-            } else {
+            } else if (System.getProperty("os.name").toLowerCase().contains("linux")) {
+                return "/opt/emrick-designer/" + path;
+            }
+            else {
                 return "/Applications/Emrick Designer.app/Contents/" + path;
             }
         }


### PR DESCRIPTION
Emrick Designer is now linux-compatible (at least it should be with Debian based distributions. Ubuntu is the only distro it has been tested on.) Changes made to build.gradle, build.sh, and PathConverter to add linux support.