### PR TITLE
Timeline Scrub Bar and Timing based on Counts

### DIFF
--- a/src/main/java/org/emrick/project/MediaEditorGUI.java
+++ b/src/main/java/org/emrick/project/MediaEditorGUI.java
@@ -2978,7 +2978,7 @@ public class MediaEditorGUI extends Component implements ImportListener, ScrubBa
         ledStripViewGUI.setCurrentMS(time);
 
         // sync timeline with scrub bar
-        timelineGUI.scrubTimeline(scrubBarGUI.getTime() * 1000);
+        timelineGUI.scrubToMS(scrubBarGUI.getTime() * 1000);
     }
 
     @Override
@@ -3209,8 +3209,8 @@ public class MediaEditorGUI extends Component implements ImportListener, ScrubBa
     //////////////////////////// Timeline Listeners //////////////////////////
     
     @Override
-    public void onTimelineScrub(int count) {
-        scrubBarGUI.setScrub(count);
+    public void onTimelineScrub(double count) {
+        scrubBarGUI.setScrub((int)count);
     }
 
     ////////////////////////// RF Trigger Listeners //////////////////////////

--- a/src/main/java/org/emrick/project/MediaEditorGUI.java
+++ b/src/main/java/org/emrick/project/MediaEditorGUI.java
@@ -33,7 +33,7 @@ import java.util.Properties;
  */
 public class MediaEditorGUI extends Component implements ImportListener, ScrubBarListener, SyncListener,
         FootballFieldListener, EffectListener, SelectListener, UserAuthListener, RFTriggerListener, RFSignalListener, RequestCompleteListener,
-        LEDConfigListener, ReplaceFilesListener {
+        LEDConfigListener, ReplaceFilesListener, TimelineListener {
 
     // String definitions
     public static final String FILE_MENU_CONCATENATE = "Concatenate";
@@ -3206,6 +3206,13 @@ public class MediaEditorGUI extends Component implements ImportListener, ScrubBa
         updateTimelinePanel();
     }
 
+    //////////////////////////// Timeline Listeners //////////////////////////
+    
+    @Override
+    public void onTimelineScrub(int count) {
+        scrubBarGUI.setScrub(count);
+    }
+
     ////////////////////////// RF Trigger Listeners //////////////////////////
 
     @Override
@@ -3241,6 +3248,7 @@ public class MediaEditorGUI extends Component implements ImportListener, ScrubBa
     @Override
     public void onPressRFTrigger(RFTrigger rfTrigger) {
         // scrub to this rf trigger
+        System.out.println("MediaEditorGUI: onPressRFTrigger() called with count: " + rfTrigger.getCount() + " and ms: " + rfTrigger.getTimestampMillis());
         scrubBarGUI.setScrub(rfTrigger.getCount());
     }
 
@@ -3412,7 +3420,8 @@ public class MediaEditorGUI extends Component implements ImportListener, ScrubBa
             }
         }
         ArrayList<Effect> effectsList = new ArrayList<>(effectsSet);
-        timelineGUI = new TimelineGUI(effectsList, count2RFTrigger);
+        timelineGUI = new TimelineGUI(effectsList, count2RFTrigger, timeManager);
+        timelineGUI.setTimelineListener(this);
 
         timelinePanel.add(timelineGUI.getTimelineScrollPane());
         timelinePanel.revalidate();

--- a/src/main/java/org/emrick/project/PanningMouseAdapter.java
+++ b/src/main/java/org/emrick/project/PanningMouseAdapter.java
@@ -1,0 +1,221 @@
+package org.emrick.project;
+
+import java.awt.Cursor;
+import java.awt.Point;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+
+import javax.swing.JComponent;
+import javax.swing.JScrollPane;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
+
+/**
+ * Scroll-click drag panning adapter implementation
+ * Provides smooth, precise panning of Swing components using the scroll-click (middle mouse button)
+ * This implementation directly manipulates the viewport position to ensure content
+ * moves exactly with the mouse cursor, providing the most natural panning experience
+ */
+class PanningMouseAdapter extends MouseAdapter {
+    private final JComponent component;
+    private final JScrollPane scrollPane;
+    private Point holdPoint;
+    private Runnable afterPanAction;
+    
+    /**
+     * Creates a new panning adapter for the specified component and scroll pane
+     * 
+     * @param component The component to enable panning for
+     * @param scrollPane The scroll pane containing the component
+     */
+    public PanningMouseAdapter(JComponent component, JScrollPane scrollPane) {
+        this.component = component;
+        this.scrollPane = scrollPane;
+        
+        // Initialize mouse listeners safely
+        initializeListeners();
+    }
+    
+    /**
+     * Creates a new panning adapter with a callback that runs after each pan movement
+     * 
+     * @param component The component to enable panning for
+     * @param scrollPane The scroll pane containing the component
+     * @param afterPanAction Action to run after each pan movement (e.g., repainting other components)
+     */
+    public PanningMouseAdapter(JComponent component, JScrollPane scrollPane, Runnable afterPanAction) {
+        this.component = component;
+        this.scrollPane = scrollPane;
+        this.afterPanAction = afterPanAction;
+        
+        // Initialize mouse listeners safely
+        initializeListeners();
+    }
+    
+    /**
+     * Safely initialize the mouse listeners to avoid "leaking this" warning
+     */
+    private void initializeListeners() {
+        // Using a separate method to add listeners avoids the "leaking this in constructor" warning
+        component.addMouseListener(this);
+        component.addMouseMotionListener(this);
+    }
+    
+    @Override
+    public void mousePressed(MouseEvent e) {
+        if (e.getButton() == MouseEvent.BUTTON2) {
+            component.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+            holdPoint = e.getPoint();
+            e.consume();
+        }
+    }
+    
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        if (holdPoint != null && e.getButton() == MouseEvent.BUTTON2) {
+            component.setCursor(null);
+            holdPoint = null;
+            e.consume();
+        }
+    }
+    
+    @Override
+    public void mouseDragged(MouseEvent e) {
+        if (holdPoint != null) {
+            // Get current point
+            Point dragPoint = e.getPoint();
+            
+            // Find viewport
+            JViewport viewport = scrollPane.getViewport();
+            
+            if (viewport != null) {
+                // Get current viewport position
+                Point viewPos = viewport.getViewPosition();
+                
+                // Calculate maximum bounds
+                int maxViewPosX = component.getWidth() - viewport.getWidth();
+                int maxViewPosY = component.getHeight() - viewport.getHeight();
+                
+                // Handle horizontal scrolling
+                if (component.getWidth() > viewport.getWidth()) {
+                    viewPos.x -= (dragPoint.x - holdPoint.x);
+                    
+                    // Handle boundaries
+                    if (viewPos.x < 0) {
+                        viewPos.x = 0;
+                        holdPoint.x = dragPoint.x;
+                    }
+                    
+                    if (viewPos.x > maxViewPosX) {
+                        viewPos.x = maxViewPosX;
+                        holdPoint.x = dragPoint.x;
+                    }
+                }
+                
+                // Handle vertical scrolling
+                if (component.getHeight() > viewport.getHeight()) {
+                    viewPos.y -= (dragPoint.y - holdPoint.y);
+                    
+                    // Handle boundaries
+                    if (viewPos.y < 0) {
+                        viewPos.y = 0;
+                        holdPoint.y = dragPoint.y;
+                    }
+                    
+                    if (viewPos.y > maxViewPosY) {
+                        viewPos.y = maxViewPosY;
+                        holdPoint.y = dragPoint.y;
+                    }
+                }
+                
+                // Apply new position
+                viewport.setViewPosition(viewPos);
+                
+                // Execute after-pan action if provided (e.g., repaint other components)
+                if (afterPanAction != null) {
+                    afterPanAction.run();
+                }
+                
+                e.consume();
+            }
+        }
+    }
+    
+    /**
+     * Makes a component transparent to middle mouse events and passes them through
+     * to a target component. This allows clicking through widgets like buttons and labels
+     * to enable panning on the underlying component.
+     * 
+     * @param component The component to make transparent to middle mouse events
+     * @param target The target component to which events should be forwarded
+     * @return The MouseAdapter that was added to the component for event forwarding
+     */
+    public static MouseAdapter passMiddleMouseEvents(JComponent component, JComponent target) {
+        MouseAdapter mouseAdapter = new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON2) {
+                    // Forward the event to the target component
+                    Point point = SwingUtilities.convertPoint(component, e.getPoint(), target);
+                    target.dispatchEvent(new MouseEvent(
+                        target, 
+                        e.getID(), 
+                        e.getWhen(), 
+                        e.getModifiersEx(), 
+                        point.x, point.y, 
+                        e.getClickCount(), 
+                        e.isPopupTrigger(), 
+                        e.getButton()
+                    ));
+                    e.consume();
+                }
+            }
+            
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON2) {
+                    // Forward the event to the target component
+                    Point point = SwingUtilities.convertPoint(component, e.getPoint(), target);
+                    target.dispatchEvent(new MouseEvent(
+                        target, 
+                        e.getID(), 
+                        e.getWhen(), 
+                        e.getModifiersEx(), 
+                        point.x, point.y, 
+                        e.getClickCount(), 
+                        e.isPopupTrigger(), 
+                        e.getButton()
+                    ));
+                    e.consume();
+                }
+            }
+        };
+        
+        MouseMotionAdapter motionAdapter = new MouseMotionAdapter() {
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                if ((e.getModifiersEx() & MouseEvent.BUTTON2_DOWN_MASK) != 0) {
+                    // Forward the event to the target component
+                    Point point = SwingUtilities.convertPoint(component, e.getPoint(), target);
+                    target.dispatchEvent(new MouseEvent(
+                        target, 
+                        e.getID(), 
+                        e.getWhen(), 
+                        e.getModifiersEx(), 
+                        point.x, point.y, 
+                        e.getClickCount(), 
+                        e.isPopupTrigger(), 
+                        e.getButton()
+                    ));
+                    e.consume();
+                }
+            }
+        };
+        
+        component.addMouseListener(mouseAdapter);
+        component.addMouseMotionListener(motionAdapter);
+        
+        return mouseAdapter; // Return the adapter for potential removal later
+    }
+}

--- a/src/main/java/org/emrick/project/TimeManager.java
+++ b/src/main/java/org/emrick/project/TimeManager.java
@@ -71,35 +71,56 @@ public class TimeManager {
         buildSet2MSec(set2CountSorted, count2MSec);
     }
 
+    // Optimized: Use binary search for efficient lookup since counts are sequential integers
     public int MSec2Count(long ms) {
-        for (Map.Entry<Integer, Long> entry : count2MSec.entrySet()) {
-            if (entry.getValue() > ms) return entry.getKey() - 1;
+        int low = 0;
+        int high = count2MSec.size() - 1;
+        int result = -1;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            Long value = count2MSec.get(mid);
+            if (value == null) break;
+            if (value > ms) {
+                result = mid - 1;
+                high = mid - 1;
+            } else {
+                low = mid + 1;
+            }
         }
-        System.out.println("count found: " + count2MSec.size() + " for ms: " + ms);
-        return count2MSec.size();
+        if (result == -1) {
+            // ms is before the first count
+            return 0;
+        }
+        if (result >= count2MSec.size()) {
+            // ms is beyond the last count
+            return count2MSec.size() - 1;
+        }
+        return result;
     }
 
     // This method is more precise, returning count including subsets of it for smoother timeline playback
     // It gets the exact count then adds the percent to the next count
     public double MSec2CountPrecise(long ms) {
-        long count = 0;
-        double percentToNext = 0;
-
-        for (Map.Entry<Integer, Long> entry : count2MSec.entrySet()) {
-            if (entry.getValue() > ms) {
-                count = entry.getKey() - 1;
-                if (count != count2MSec.size() - 1) { // Get the percent to the next count if there is a next count
-                    long curMS = count2MSec.get((int) count);
-                    int nextCountKey = (int) count + 1;
-                    Long nextCountMSec = count2MSec.get(nextCountKey);
-                    if (nextCountMSec != null && nextCountMSec > curMS) {
-                        percentToNext = (double) (ms - curMS) / (nextCountMSec - curMS);
-                    }
-                }
-                break;
+        int low = 0;
+        int high = count2MSec.size() - 1;
+        int prevKey = -1;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            Long value = count2MSec.get(mid);
+            if (value == null) break;
+            if (value > ms) {
+                prevKey = mid - 1;
+                high = mid - 1;
+            } else {
+                low = mid + 1;
             }
         }
-        return count + percentToNext;
+        if (prevKey < 0) return 0.0;
+        if (prevKey >= count2MSec.size() - 1) return count2MSec.size() - 1;
+        long curMS = count2MSec.get(prevKey);
+        long nextMS = count2MSec.get(prevKey + 1);
+        double percentToNext = (nextMS > curMS) ? (double) (ms - curMS) / (nextMS - curMS) : 0.0;
+        return prevKey + percentToNext;
     }
 
     private void buildSet2MSec(ArrayList<Map.Entry<String, Integer>> set2CountSorted, HashMap<Integer, Long> count2MSec) {

--- a/src/main/java/org/emrick/project/TimeManager.java
+++ b/src/main/java/org/emrick/project/TimeManager.java
@@ -84,29 +84,21 @@ public class TimeManager {
     public double MSec2CountPrecise(long ms) {
         long count = 0;
         double percentToNext = 0;
-        System.out.println("MSec2CountPrecise called with ms: " + ms);
 
         for (Map.Entry<Integer, Long> entry : count2MSec.entrySet()) {
-            System.out.println("Checking count: " + entry.getKey() + ", time: " + entry.getValue());
             if (entry.getValue() > ms) {
                 count = entry.getKey() - 1;
-                System.out.println("Found count: " + count + " for ms: " + ms);
                 if (count != count2MSec.size() - 1) { // Get the percent to the next count if there is a next count
                     long curMS = count2MSec.get((int) count);
                     int nextCountKey = (int) count + 1;
                     Long nextCountMSec = count2MSec.get(nextCountKey);
-                    System.out.println("curMS: " + curMS + ", nextCountMSec: " + nextCountMSec);
                     if (nextCountMSec != null && nextCountMSec > curMS) {
                         percentToNext = (double) (ms - curMS) / (nextCountMSec - curMS);
-                        System.out.println("percentToNext: " + percentToNext);
-                    } else {
-                        System.out.println("No valid next count or nextCountMSec <= curMS");
                     }
                 }
                 break;
             }
         }
-        System.out.println("Returning: " + (count + percentToNext));
         return count + percentToNext;
     }
 

--- a/src/main/java/org/emrick/project/TimeManager.java
+++ b/src/main/java/org/emrick/project/TimeManager.java
@@ -73,10 +73,42 @@ public class TimeManager {
 
     public int MSec2Count(long ms) {
         for (Map.Entry<Integer, Long> entry : count2MSec.entrySet()) {
-            if (entry.getValue() >= ms) return entry.getKey();
+            if (entry.getValue() > ms) return entry.getKey() - 1;
         }
+        System.out.println("count found: " + count2MSec.size() + " for ms: " + ms);
         return count2MSec.size();
-    } // not entirely sure if this returns count or count + 1
+    }
+
+    // This method is more precise, returning count including subsets of it for smoother timeline playback
+    // It gets the exact count then adds the percent to the next count
+    public double MSec2CountPrecise(long ms) {
+        long count = 0;
+        double percentToNext = 0;
+        System.out.println("MSec2CountPrecise called with ms: " + ms);
+
+        for (Map.Entry<Integer, Long> entry : count2MSec.entrySet()) {
+            System.out.println("Checking count: " + entry.getKey() + ", time: " + entry.getValue());
+            if (entry.getValue() > ms) {
+                count = entry.getKey() - 1;
+                System.out.println("Found count: " + count + " for ms: " + ms);
+                if (count != count2MSec.size() - 1) { // Get the percent to the next count if there is a next count
+                    long curMS = count2MSec.get((int) count);
+                    int nextCountKey = (int) count + 1;
+                    Long nextCountMSec = count2MSec.get(nextCountKey);
+                    System.out.println("curMS: " + curMS + ", nextCountMSec: " + nextCountMSec);
+                    if (nextCountMSec != null && nextCountMSec > curMS) {
+                        percentToNext = (double) (ms - curMS) / (nextCountMSec - curMS);
+                        System.out.println("percentToNext: " + percentToNext);
+                    } else {
+                        System.out.println("No valid next count or nextCountMSec <= curMS");
+                    }
+                }
+                break;
+            }
+        }
+        System.out.println("Returning: " + (count + percentToNext));
+        return count + percentToNext;
+    }
 
     private void buildSet2MSec(ArrayList<Map.Entry<String, Integer>> set2CountSorted, HashMap<Integer, Long> count2MSec) {
         set2MSec = new ArrayList<>();

--- a/src/main/java/org/emrick/project/TimelineGUI.java
+++ b/src/main/java/org/emrick/project/TimelineGUI.java
@@ -116,13 +116,13 @@ public class TimelineGUI {
         maxCount += 5;
         
         createTimelinePane();
-        createZoomControls();
+        //createZoomControls();
         
         // Initialize scrub bar
         scrubBar = new TimelineScrubBar();
         
         mainPanel = new JPanel(new BorderLayout());
-        mainPanel.add(zoomPanel, BorderLayout.NORTH);
+        //mainPanel.add(zoomPanel, BorderLayout.NORTH);
         
         // Create a panel to hold the scrub bar and timeline
         JPanel timelineContainer = new JPanel(new BorderLayout());
@@ -233,9 +233,11 @@ public class TimelineGUI {
      * Updates the zoom display and timeline layout
      */
     private void updateZoom() {
-        zoomLabel.setText(String.format("Zoom: %.1fx", zoomFactor));
         updateTimelineLayout();
         scrubToMS(curMS);
+        if (zoomLabel != null) {
+            zoomLabel.setText(String.format("Zoom: %.1fx", zoomFactor));
+        }
     }
 
     private void updateTimelineLayout() {

--- a/src/main/java/org/emrick/project/TimelineGUI.java
+++ b/src/main/java/org/emrick/project/TimelineGUI.java
@@ -25,7 +25,9 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToggleButton;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
+import org.emrick.project.SyncTimeGUI.Pair;
 import org.emrick.project.effect.Effect;
 import org.emrick.project.effect.RFTrigger;
 import org.emrick.project.effect.TimelineEvent;
@@ -46,17 +48,27 @@ public class TimelineGUI {
     private JLabel zoomLabel;
     private static double zoomFactor = 1.0;
     private static final double MIN_ZOOM = 0.1;
-    private static final double MAX_ZOOM = 5.0;
+    private static final double MAX_ZOOM = 10.0;
     private static final double ZOOM_STEP = 0.1;
     
     // Base dimensions
     private static final int ROW_HEIGHT = 70;
     private static final int TRIGGER_ROW_HEIGHT = 60;
-    private static final int PIXELS_PER_SECOND = 20; // Base scale: 20 pixels per second at zoom 1.0
-      // Track the total duration for scaling
-    private final double totalDurationMSec;
-    private static double curMSec;
-    public TimelineGUI(ArrayList<Effect> effects, HashMap<Integer, RFTrigger> count2RFTrigger) {
+    private static final int PIXELS_PER_COUNT = 10; // Base scale: 10 pixels per count at zoom 1.0
+    // Track the count position instead of time
+    private final double totalDurationMSec; // Keeping for compatibility
+    private static double curMSec;          // Keeping for compatibility
+    private static double currentCount = 0;  // Current count position with fractional part
+    private int maxCount;                   // Maximum count in the timeline
+    
+    // Scrub bar component
+    private TimelineScrubBar scrubBar;
+
+    private TimeManager timeManager;
+    private TimelineListener timelineListener;
+
+    public TimelineGUI(ArrayList<Effect> effects, HashMap<Integer, RFTrigger> count2RFTrigger, TimeManager timeManager) {
+        this.timeManager = timeManager;
         this.effects = effects;
         if (this.effects == null) {
             this.effects = new ArrayList<>();
@@ -94,18 +106,57 @@ public class TimelineGUI {
         totalDurationMSec = timelineEvents.isEmpty() ? 1000 : 
                            timelineEvents.get(timelineEvents.size() - 1).getKey() + 1000;
         
+        // Calculate the maximum count based on triggers
+        maxCount = 0;
+        for (RFTrigger trigger : triggers) {
+            maxCount = Math.max(maxCount, trigger.getCount());
+        }
+        // Add some padding to the end
+        maxCount += 5;
+        
         createTimelinePane();
-        createZoomControls();        mainPanel = new JPanel(new BorderLayout());
+        createZoomControls();
+        
+        // Initialize scrub bar
+        scrubBar = new TimelineScrubBar();
+        
+        mainPanel = new JPanel(new BorderLayout());
         mainPanel.add(zoomPanel, BorderLayout.NORTH);
-        mainPanel.add(timelineScrollPane, BorderLayout.CENTER);
-          // Add mouse wheel listener for zooming with Ctrl+Scroll
+        
+        // Create a panel to hold the scrub bar and timeline
+        JPanel timelineContainer = new JPanel(new BorderLayout());
+        
+        // Wrap the scrub bar in a panel to ensure it doesn't get clipped
+        JPanel scrubBarContainer = new JPanel(new BorderLayout());
+        scrubBarContainer.add(scrubBar, BorderLayout.CENTER);
+        scrubBarContainer.setPreferredSize(new Dimension(calculateTimelineWidth(), scrubBar.getPreferredSize().height));
+        
+        timelineContainer.add(scrubBarContainer, BorderLayout.NORTH);
+        timelineContainer.add(timelineScrollPane, BorderLayout.CENTER);
+        
+        mainPanel.add(timelineContainer, BorderLayout.CENTER);
+        
+        // Add mouse wheel listener for zooming with Ctrl+Scroll
         addMouseWheelZoomSupport();
 
         // Add a small delay before scrubbing to ensure all components are properly initialized
         SwingUtilities.invokeLater(() -> {
             scrubTimeline(curMSec);
-            System.out.println("curMSec: " + curMSec);
+            System.out.println("curMSec: " + curMSec + ", currentCount: " + currentCount);
         });
+    }
+
+    public TimelineGUI(ArrayList<Effect> effects, HashMap<Integer, RFTrigger> count2RFTrigger, TimeManager timeManager, TimelineListener listener) {
+        this(effects, count2RFTrigger, timeManager);
+        this.timelineListener = listener;
+    }
+    
+    /**
+     * Sets the timeline listener for this timeline
+     * @param listener The listener to receive timeline events
+     */
+    public void setTimelineListener(TimelineListener listener) {
+        this.timelineListener = listener;
     }
 
     /**
@@ -186,6 +237,11 @@ public class TimelineGUI {
     private void updateTimelineLayout() {
         int width = calculateTimelineWidth();
         timelinePanel.setPreferredSize(new Dimension(width, TRIGGER_ROW_HEIGHT + ROW_HEIGHT));
+        
+        // Update scrub bar size
+        scrubBar.updateSize();
+        scrubBar.getParent().setPreferredSize(new Dimension(width, scrubBar.getPreferredSize().height));
+        
         updateComponentPositions();
         timelinePanel.revalidate();
         timelinePanel.repaint();
@@ -200,7 +256,7 @@ public class TimelineGUI {
         
         // Add RF Triggers (first row)
         ArrayList<RFTrigger> sortedTriggers = new ArrayList<>(triggers);
-        sortedTriggers.sort(Comparator.comparingLong(RFTrigger::getTimestampMillis));
+        sortedTriggers.sort(Comparator.comparingInt(RFTrigger::getCount));
         
         for (int i = 0; i < sortedTriggers.size(); i++) {
             RFTrigger trigger = sortedTriggers.get(i);
@@ -209,17 +265,20 @@ public class TimelineGUI {
             // Add to button group
             triggersButtonGroup.add(triggerWidget);
             
-            int xPosition = calculateXPosition(trigger.getTimestampMillis());
+            // Position based directly on count
+            int count = trigger.getCount();
+            int xPosition = (int)(count * PIXELS_PER_COUNT * zoomFactor);
             
             // Calculate width to next trigger or end
             int width;
             if (i < sortedTriggers.size() - 1) {
-                long nextTriggerTime = sortedTriggers.get(i + 1).getTimestampMillis();
-                width = calculateXPosition(nextTriggerTime) - xPosition;
+                int nextCount = sortedTriggers.get(i + 1).getCount();
+                width = (int)((nextCount - count) * PIXELS_PER_COUNT * zoomFactor);
             } else {
-                width = calculateXPosition(totalDurationMSec) - xPosition;
+                width = (int)(PIXELS_PER_COUNT * zoomFactor * 2); // Default width for last trigger
             }
-              // Ensure minimum width and prevent overlap
+            
+            // Ensure minimum width and prevent overlap
             width = Math.max(width - 2, 10); // Subtract 2 pixels to prevent overlap, ensure minimum width
             
             triggerWidget.setBounds(xPosition, 0, width, TRIGGER_ROW_HEIGHT);
@@ -234,9 +293,13 @@ public class TimelineGUI {
         sortedEffects.sort(Comparator.comparingLong(Effect::getStartTimeMSec));
         
         for (Effect effect : sortedEffects) {
+            // Convert effect start time to count
+            double effectStartCount = timeManager.MSec2CountPrecise((long)effect.getStartTimeMSec());
+            double effectEndCount = timeManager.MSec2CountPrecise((long)(effect.getStartTimeMSec() + effect.getDuration().toMillis()));
+
             TimeRange effectRange = new TimeRange(
-                effect.getStartTimeMSec(),
-                effect.getStartTimeMSec() + effect.getDuration().toMillis()
+                effectStartCount,
+                effectEndCount
             );
             
             int rowIndex = findAvailableRow(effectRows, effectRange);
@@ -245,8 +308,10 @@ public class TimelineGUI {
             
             // Add to button group
             effectsButtonGroup.add(effectWidget);
-              int xPosition = calculateXPosition(effect.getStartTimeMSec());
-            int width = calculateEffectWidth(effect);
+            
+            // Position based on counts
+            int xPosition = (int)(effectStartCount * PIXELS_PER_COUNT * zoomFactor);
+            int width = (int)((effectEndCount - effectStartCount) * PIXELS_PER_COUNT * zoomFactor);
             int yPosition = TRIGGER_ROW_HEIGHT + (rowIndex * ROW_HEIGHT);
             
             // Ensure minimum width
@@ -274,12 +339,13 @@ public class TimelineGUI {
             protected void paintChildren(Graphics g) {
                 super.paintChildren(g);
                 
-                // Draw the redline at current time position after all children are drawn
+                // Draw the redline at current count position after all children are drawn
                 Graphics2D g2d = (Graphics2D) g;
                 g2d.setColor(new Color(255, 0, 0, 128)); // Semi-transparent red
                 g2d.setStroke(new BasicStroke(2.0f));
                 
-                int xPosition = calculateXPosition(curMSec);
+                // Draw based on current count instead of time
+                int xPosition = (int)(currentCount * PIXELS_PER_COUNT * zoomFactor);
                 g2d.drawLine(xPosition, 0, xPosition, getHeight());
             }
         };
@@ -290,19 +356,28 @@ public class TimelineGUI {
         timelineScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
         timelineScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         timelineScrollPane.setBorder(BorderFactory.createEmptyBorder());
+        
+        // Make the scrub bar synchronized with the timeline horizontal scrolling
+        timelineScrollPane.getHorizontalScrollBar().addAdjustmentListener(e -> {
+            scrubBar.repaint();
+        });
     }
 
-    private int calculateXPosition(double timestampMillis) {
-        return (int)((timestampMillis * PIXELS_PER_SECOND * zoomFactor) / 1000);
+    private int calculateXPosition(double ms) {
+        double count = timeManager.MSec2CountPrecise((long)ms);
+        return (int)(count * PIXELS_PER_COUNT * zoomFactor);
     }
 
     private int calculateEffectWidth(Effect effect) {
         long durationMillis = effect.getDuration().toMillis();
-        return (int)((durationMillis * PIXELS_PER_SECOND * zoomFactor) / 1000);
+        // Convert duration to count-based width
+        // This is an approximation - assumes 1 second per count
+        return (int)((durationMillis / 1000.0) * PIXELS_PER_COUNT * zoomFactor);
     }
 
     private int calculateTimelineWidth() {
-        return (int)((totalDurationMSec * PIXELS_PER_SECOND * zoomFactor) / 1000);
+        // Use maxCount to determine the timeline width
+        return (int)(maxCount * PIXELS_PER_COUNT * zoomFactor) + PIXELS_PER_COUNT; // Add extra space at the end
     }
     
     private int findAvailableRow(List<List<TimeRange>> rows, TimeRange newRange) {
@@ -329,10 +404,10 @@ public class TimelineGUI {
     }
 
     private static class TimeRange {
-        long start;
-        long end;
-        
-        TimeRange(long start, long end) {
+        double start;
+        double end;
+
+        TimeRange(double start, double end) {
             this.start = start;
             this.end = end;
         }
@@ -342,23 +417,253 @@ public class TimelineGUI {
         }
     }
 
+    /**
+     * A scrub bar component with tick marks for counts
+     * Shows tick marks for each count with labels for every 4th count
+     */
+    private class TimelineScrubBar extends JPanel {
+        private static final int SCRUB_BAR_HEIGHT = 20;
+        private static final int TICK_HEIGHT = 3;
+        private static final int MAJOR_TICK_HEIGHT = 6;
+        private static final int LABEL_OFFSET = -2;
+        
+        // Track mouse interaction
+        public boolean isDragging = false;
+        
+        public TimelineScrubBar() {
+            setPreferredSize(new Dimension(calculateTimelineWidth(), SCRUB_BAR_HEIGHT));
+            
+            // Add mouse listeners for scrubbing
+            addMouseListener(new java.awt.event.MouseAdapter() {
+                @Override
+                public void mousePressed(java.awt.event.MouseEvent e) {
+                    isDragging = true;
+                    updateTimeFromMouse(e.getX());
+                }
+                
+                @Override
+                public void mouseReleased(java.awt.event.MouseEvent e) {
+                    isDragging = false;
+                }
+                
+                @Override
+                public void mouseClicked(java.awt.event.MouseEvent e) {
+                    updateTimeFromMouse(e.getX());
+                }
+            });
+            
+            addMouseMotionListener(new java.awt.event.MouseMotionAdapter() {
+                @Override
+                public void mouseDragged(java.awt.event.MouseEvent e) {
+                    if (isDragging) {
+                        updateTimeFromMouse(e.getX());
+                    }
+                }
+            });
+        }
+        
+        private void updateTimeFromMouse(int x) {
+            // Adjust x for scroll position
+            int scrollX = timelineScrollPane.getHorizontalScrollBar().getValue();
+            int adjustedX = x + scrollX;
+            int viewportWidth = timelineScrollPane.getViewport().getWidth();
+            
+            // Convert x position directly to a count
+            int clickedCount = (int)(adjustedX / (PIXELS_PER_COUNT * zoomFactor));
+            System.out.println("Clicked count: " + clickedCount + 
+                              ", Mouse X: " + x + 
+                              ", Scroll X: " + scrollX + 
+                              ", Viewport Width: " + viewportWidth);
+            
+            // Find the nearest trigger within a threshold (for snapping)
+                RFTrigger nearestTrigger = null;
+                int minDistance = Integer.MAX_VALUE;
+                
+            for (RFTrigger trigger : triggers) {
+                int distance = Math.abs(trigger.getCount() - clickedCount);
+                if (distance < minDistance && distance <= 1) { // Threshold of 1 count for snapping
+                    minDistance = distance;
+                    nearestTrigger = trigger;
+                }
+            }
+        
+            // If we found a nearby trigger, scrub to that count
+            if (nearestTrigger != null) {
+                scrubToCount(nearestTrigger.getCount());
+            } else {
+                // Directly scrub to the clicked count
+                scrubToCount(clickedCount);
+            }
+        }
+        
+        @Override
+        public void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            Graphics2D g2d = (Graphics2D) g;
+            
+            // Get scroll position
+            int scrollX = timelineScrollPane.getHorizontalScrollBar().getValue();
+            
+            // Draw the timeline background
+            g2d.setColor(UIManager.getColor("Panel.background"));
+            g2d.fillRect(0, 0, getWidth(), getHeight());
+            
+            // Draw the tick marks and count labels
+            g2d.setColor(UIManager.getColor("Component.borderColor"));
+
+            // Calculate the visible range in counts
+            int visibleWidth = getWidth();
+            int startX = scrollX;
+            int endX = startX + visibleWidth;
+            
+            // Calculate the count range to draw
+            int startCount = Math.max(0, (int)(startX / (PIXELS_PER_COUNT * zoomFactor)));
+            int endCount = Math.min(maxCount, (int)(endX / (PIXELS_PER_COUNT * zoomFactor)) + 2);
+            
+            // Draw count markers
+            for (int count = startCount; count <= endCount; count++) {
+                // Calculate x position for this count
+                int x = (int)(count * PIXELS_PER_COUNT * zoomFactor) - scrollX;
+                
+                // Check if this count has a trigger
+                boolean hasTrigger = false;
+                for (RFTrigger trigger : triggers) {
+                    if (trigger.getCount() == count) {
+                        hasTrigger = true;
+                        break;
+                    }
+                }
+                
+                // Draw a tick mark
+                if (count % 4 == 0) {
+                    // Draw a major tick mark with label for every 4th count
+                    g2d.drawLine(x, 0, x, MAJOR_TICK_HEIGHT);
+                    
+                    // Draw the count label
+                    String countLabel = Integer.toString(count);
+                    java.awt.FontMetrics fm = g2d.getFontMetrics();
+                    int labelWidth = fm.stringWidth(countLabel);
+                    
+                    g2d.drawString(countLabel, x - labelWidth / 2, MAJOR_TICK_HEIGHT + LABEL_OFFSET + fm.getAscent());
+                } else {
+                    // Draw a minor tick mark
+                    g2d.drawLine(x, 0, x, TICK_HEIGHT);
+                }
+                
+                // Highlight counts with triggers
+                if (hasTrigger) {
+                    g2d.setColor(new Color(0, 0, 255, 40)); // Light blue
+                    g2d.fillRect(x - 2, 0, 4, MAJOR_TICK_HEIGHT);
+                    g2d.setColor(UIManager.getColor("Component.borderColor"));
+                }
+            }
+            
+            // Draw the current position indicator (red line)
+            g2d.setColor(Color.RED);
+            g2d.setStroke(new BasicStroke(2.0f));
+            
+            // Draw based on current count
+            int xPosition = (int)(currentCount * PIXELS_PER_COUNT * zoomFactor) - scrollX;
+            
+            // Only draw if in visible range
+            if (xPosition >= 0 && xPosition <= visibleWidth) {
+                g2d.drawLine(xPosition, 0, xPosition, getHeight());
+            }
+        }
+        
+        public void updateSize() {
+            setPreferredSize(new Dimension(calculateTimelineWidth(), SCRUB_BAR_HEIGHT));
+            revalidate();
+            repaint();
+        }
+    }
+
     public void scrubTimeline(double ms) {
+        if (scrubBar.isDragging) { return; } // Don't scrub if dragging the scrub bar
         // Calculate the x position for the given time
         int xPosition = calculateXPosition(ms);
-        // Get the viewport width
-        int scrollPosition = (int) Math.max(0, xPosition - (PIXELS_PER_SECOND * 20));
+        // Set current position
         curMSec = ms;
+        // Update current count based on the timestamp
+        currentCount = timeManager.MSec2CountPrecise((long)ms);
         
+        // Calculate scroll position to ensure current position is visible
+        // Aim to position the current count with some padding to the left based on frame width
+        int scrollPosition = (int) Math.max(0, xPosition - (timelineScrollPane.getWidth() / 2));
+
         // Update the scroll position and redraw the timeline
         SwingUtilities.invokeLater(() -> {
             timelineScrollPane.getHorizontalScrollBar().setValue(scrollPosition);
-            timelinePanel.repaint(); // Add this line to trigger redraw
+            timelinePanel.repaint(); // Redraw timeline
+            scrubBar.repaint();      // Redraw scrub bar
         });
     }
 
-    public static void setCurMSec(long curMSec) {
-        TimelineGUI.curMSec = curMSec;
-        System.out.println("TimelineGUI: setCurMSec = " + curMSec);
+    /**
+     * Scrub to a specific count
+     */
+    public void scrubToCount(int count) {
+        // Find a trigger at this count if possible
+        RFTrigger triggerAtCount = null;
+        for (RFTrigger trigger : triggers) {
+            if (trigger.getCount() == count) {
+                triggerAtCount = trigger;
+                break;
+            }
+        }
+        
+        // If we found a trigger, use its time
+        if (triggerAtCount != null) {
+            curMSec = triggerAtCount.getTimestampMillis();
+            // Use the precise method to get the exact count
+            currentCount = triggerAtCount.getCount();
+        } else {
+            // Otherwise estimate time based on count (1 second per count)
+            curMSec = count * 1000;
+            currentCount = count; // Exact count as a double
+        }
+        
+        // Notify listener of the timeline scrub action to keep other components in sync
+        if (timelineListener != null) {
+            timelineListener.onTimelineScrub(count);
+        }
+        
+        // Calculate x position
+        int xPosition = (int)(currentCount * PIXELS_PER_COUNT * zoomFactor);
+        
+        // Get current scroll position and viewport width
+        JScrollPane scrollPane = timelineScrollPane;
+        int currentScrollX = scrollPane.getHorizontalScrollBar().getValue();
+        int viewportWidth = scrollPane.getViewport().getWidth();
+        
+        // Calculate the offset of the xPosition within the visible viewport
+        int offsetInViewport = xPosition - currentScrollX;
+        
+        // Only scroll if position is outside the "safe zone" (more than 50px from edges)
+        int scrollPosition = currentScrollX;
+        
+        // If position is less than 50 pixels from left edge, scroll left to give 50px margin
+        if (offsetInViewport < 50) {
+            scrollPosition = Math.max(0, xPosition - 50);
+        } 
+        // If position is less than 50 pixels from right edge, scroll right to give 50px margin
+        else if (offsetInViewport > viewportWidth - 50) {
+            scrollPosition = xPosition - (viewportWidth - 50);
+        }
+        // Otherwise, don't change the scroll position
+        
+        // Ensure we don't go beyond the bounds
+        scrollPosition = Math.max(0, scrollPosition);
+        
+        // Save the final scroll position to use in the invokeLater call
+        final int finalScrollPosition = scrollPosition;
+        
+        // Update UI
+        SwingUtilities.invokeLater(() -> {
+            timelineScrollPane.getHorizontalScrollBar().setValue(finalScrollPosition);
+            timelinePanel.repaint();
+            scrubBar.repaint();
+        });
     }
     
     public static void main(String[] args) {
@@ -368,36 +673,57 @@ public class TimelineGUI {
         frame.setLocationRelativeTo(null);
 
         ArrayList<Effect> effects = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            long startTime = Duration.ofSeconds(i * 2).toMillis();
-            Duration duration = Duration.ofSeconds(3);
-            Duration delay = Duration.ofMillis(100);
-            Duration timeout = Duration.ofSeconds(5);
-            
-            Effect e = new Effect(startTime, 
-                                Color.GREEN, Color.RED,
-                                delay, duration, timeout,
-                                true, true, true, true, i); // Added unique id for each effect
-            effects.add(e);
-        }
-
-        // Add an overlapping effect to test row placement
-        effects.add(new Effect(Duration.ofSeconds(1).toMillis(),
+        
+        // Create effects at specific count positions
+        // Time values are less important now, but still needed for compatibility
+        Effect e1 = new Effect(Duration.ofSeconds(4).toMillis(), 
+                             Color.GREEN, Color.RED,
+                             Duration.ofMillis(100), Duration.ofSeconds(3), Duration.ofSeconds(5),
+                             true, true, true, true, 1);
+        
+        Effect e2 = new Effect(Duration.ofSeconds(8).toMillis(), 
                              Color.BLUE, Color.YELLOW,
-                             Duration.ZERO, Duration.ofSeconds(4), Duration.ofSeconds(5),
-                             true, true, false, true, 5)); // Added unique id
+                             Duration.ofMillis(100), Duration.ofSeconds(4), Duration.ofSeconds(5),
+                             true, true, true, true, 2);
+                             
+        Effect e3 = new Effect(Duration.ofSeconds(16).toMillis(), 
+                             Color.RED, Color.WHITE,
+                             Duration.ofMillis(100), Duration.ofSeconds(2), Duration.ofSeconds(5),
+                             true, true, true, true, 3);
+        
+        effects.add(e1);
+        effects.add(e2);
+        effects.add(e3);
 
+        // Create triggers with explicit counts (preferred approach)
         HashMap<Integer, RFTrigger> triggers = new HashMap<>();
-        for (int i = 0; i < 3; i++) {
+        
+        // Create a trigger at every 4 counts for demonstration
+        for (int i = 0; i <= 20; i += 4) {
+            // Set count explicitly, timestamp is less important now but still needed
             RFTrigger t = new RFTrigger(i, 
-                                      Duration.ofSeconds(i * 3).toMillis(),
-                                      "Trigger " + i,
+                                      i * 1000, // milliseconds, 1 second per count
+                                      "Count " + i,
                                       "Description " + i,
                                       "Cue " + i);
             triggers.put(i, t);
         }
+        
+        // Add a few more triggers at specific counts
+        RFTrigger t1 = new RFTrigger(2, 2000, "Count 2", "Special trigger", "Cue 2");
+        RFTrigger t2 = new RFTrigger(6, 6000, "Count 6", "Special trigger", "Cue 6");
+        RFTrigger t3 = new RFTrigger(10, 10000, "Count 10", "Special trigger", "Cue 10");
+        
+        triggers.put(2, t1);
+        triggers.put(6, t2);
+        triggers.put(10, t3);
+        // Create a TimeManager instance (dummy for this example)
+        Map<String, Integer> dummyMap = new HashMap<>();
+        ArrayList<Pair> dummyList = new ArrayList<>();
+        float dummyFloat = 120.0f;
+        TimeManager timeManager = new TimeManager(dummyMap, dummyList, dummyFloat);
 
-        TimelineGUI timelineGUI = new TimelineGUI(effects, triggers);
+        TimelineGUI timelineGUI = new TimelineGUI(effects, triggers, timeManager);
         frame.add(timelineGUI.getTimelineScrollPane());
 
         frame.pack();

--- a/src/main/java/org/emrick/project/TimelineGUI.java
+++ b/src/main/java/org/emrick/project/TimelineGUI.java
@@ -474,6 +474,8 @@ public class TimelineGUI {
                               ", Mouse X: " + x + 
                               ", Scroll X: " + scrollX + 
                               ", Viewport Width: " + viewportWidth);
+            // Ensure clickedCount is within bounds
+            clickedCount = Math.max(0, Math.min(clickedCount, maxCount));
             
             // if ctrl is held down dont snap
             if (ctrlPressed) {

--- a/src/main/java/org/emrick/project/TimelineListener.java
+++ b/src/main/java/org/emrick/project/TimelineListener.java
@@ -8,5 +8,5 @@ public interface TimelineListener {
      * Called when the timeline is scrubbed to a specific count
      * @param count The count position that was scrubbed to
      */
-    void onTimelineScrub(int count);
+    void onTimelineScrub(double count);
 }

--- a/src/main/java/org/emrick/project/TimelineListener.java
+++ b/src/main/java/org/emrick/project/TimelineListener.java
@@ -1,0 +1,12 @@
+package org.emrick.project;
+
+/**
+ * Interface for receiving notifications about timeline events
+ */
+public interface TimelineListener {
+    /**
+     * Called when the timeline is scrubbed to a specific count
+     * @param count The count position that was scrubbed to
+     */
+    void onTimelineScrub(int count);
+}


### PR DESCRIPTION
easy scrubbing directly on timeline
ctrl to scrub without snapping
scroll click drag to move visually around timeline

slight blockers:
- effects only based in time 
- counts being ints

It would help if all controls in app are based in counts and only converted to time for packets
but that sounds scary to change fast and easy especially with saving but not too sure

Counts being doubles would:
- allow user to put effects off of the direct counts
- make smooth timeline playback/scrubbing less demanding (currently uses MSec2CountPrecise) which calculates what the (double)count would be

basically all conversions for counts to time should be held off until packet creation that way conversions arent demanding (or needed til end) 